### PR TITLE
Allow ECS to pull from ECR with VPC Endpoints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,12 +76,20 @@ module "logging_vpc" {
 }
 
 module "syslog_receiver_vpc" {
-  source                             = "./modules/vpc"
-  prefix                             = "${module.label.id}-syslog"
-  region                             = data.aws_region.current_region.id
-  cidr_block                         = var.syslog_receiver_cidr_block
-  propagate_private_route_tables_vgw = true
-  cidr_block_new_bits                = 2
+  source                               = "./modules/vpc"
+  prefix                               = "${module.label.id}-syslog"
+  region                               = data.aws_region.current_region.id
+  cidr_block                           = var.syslog_receiver_cidr_block
+  propagate_private_route_tables_vgw   = true
+  cidr_block_new_bits                  = 2
+  enable_logs_endpoint                 = true
+  enable_s3_endpoint                   = true
+  enable_dns_hostnames                 = true
+  enable_dns_support                   = true
+  enable_ecr_dkr_endpoint              = true
+  enable_ecr_api_endpoint              = true
+  ecr_dkr_endpoint_private_dns_enabled = true
+  ecr_api_endpoint_private_dns_enabled = true
 
   providers = {
     aws = aws.env

--- a/modules/syslog_endpoint/ecs_task_definition.tf
+++ b/modules/syslog_endpoint/ecs_task_definition.tf
@@ -26,24 +26,8 @@ resource "aws_ecs_task_definition" "server_task" {
       }
     ],
     "image": "${aws_ecr_repository.docker_repository.repository_url}",
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
-        "awslogs-region": "eu-west-2",
-        "awslogs-stream-prefix": "eu-west-2-docker-logs"
-      }
-    },
     "expanded": true
-    }, {
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
-        "awslogs-region": "eu-west-2",
-        "awslogs-stream-prefix": "eu-west-2-docker-logs"
-      }
-    },
+  }, {
     "portMappings": [
       {
         "hostPort": 80,
@@ -51,7 +35,7 @@ resource "aws_ecs_task_definition" "server_task" {
         "containerPort": 80
       }
     ],
-    "image": "${aws_ecr_repository.health_check_docker_repository.repository_url}",
+    "image": "${aws_ecr_repository.docker_repository.repository_url}:health_check",
     "name": "NGINX"
   }
 ]

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -8,6 +8,19 @@ module "vpc" {
   create_flow_log_cloudwatch_log_group = true
   enable_flow_log                      = true
 
+  enable_ecr_api_endpoint = var.enable_ecr_api_endpoint
+  enable_ecr_dkr_endpoint = var.enable_ecr_dkr_endpoint
+  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_dns_support = var.enable_dns_support
+  enable_s3_endpoint = var.enable_s3_endpoint
+  enable_logs_endpoint = var.enable_logs_endpoint
+  ecr_api_endpoint_private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
+  ecr_dkr_endpoint_private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
+
+  logs_endpoint_security_group_ids = [aws_security_group.ecr.id]
+  ecr_api_endpoint_security_group_ids  = [aws_security_group.ecr.id]
+  ecr_dkr_endpoint_security_group_ids = [aws_security_group.ecr.id]
+
   azs = [
     "${var.region}a",
     "${var.region}b",
@@ -19,4 +32,16 @@ module "vpc" {
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3)
   ]
+}
+
+resource "aws_security_group" "ecr" {
+  name   = "${var.prefix}-ecr"
+  vpc_id = module.vpc.vpc_id
+
+  egress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = [var.cidr_block]
+  }
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -19,3 +19,43 @@ variable "cidr_block_new_bits" {
   type    = number
   default = 8
 }
+
+variable "ecr_api_endpoint_private_dns_enabled" {
+  type = bool
+  default = false
+}
+
+variable "ecr_dkr_endpoint_private_dns_enabled" {
+  type = bool
+  default = false
+}
+
+variable "enable_ecr_api_endpoint" {
+  type = bool
+  default = false
+}
+
+variable "enable_ecr_dkr_endpoint" {
+  type = bool
+  default = false
+}
+
+variable "enable_dns_hostnames" {
+  type = bool
+  default = false
+}
+
+variable "enable_dns_support" {
+  type = bool
+  default = false
+}
+
+variable "enable_s3_endpoint" {
+  type = bool
+  default = false
+}
+
+variable "enable_logs_endpoint" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
There is no internet access so we need endpoints for:
ECR
S3
AWS Logs

Logging is temporarily disabled and the health check image has been
removed.

Health check image will be hosted in the same ECR repo as the service.
Logging will be restored in a future commit once awslogs-endpoint flag has been researched.