### PR TITLE
Add Internet Gateway to Syslog VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,15 +81,6 @@ module "syslog_receiver_vpc" {
   region                               = data.aws_region.current_region.id
   cidr_block                           = var.syslog_receiver_cidr_block
   propagate_private_route_tables_vgw   = true
-  cidr_block_new_bits                  = 2
-  enable_logs_endpoint                 = true
-  enable_s3_endpoint                   = true
-  enable_dns_hostnames                 = true
-  enable_dns_support                   = true
-  enable_ecr_dkr_endpoint              = true
-  enable_ecr_api_endpoint              = true
-  ecr_dkr_endpoint_private_dns_enabled = true
-  ecr_api_endpoint_private_dns_enabled = true
 
   providers = {
     aws = aws.env

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -4,22 +4,14 @@ module "vpc" {
   name                                 = var.prefix
   propagate_private_route_tables_vgw   = var.propagate_private_route_tables_vgw
   cidr                                 = var.cidr_block
+  single_nat_gateway                   = true
+  enable_nat_gateway                   = true
+
+
   create_flow_log_cloudwatch_iam_role  = true
   create_flow_log_cloudwatch_log_group = true
   enable_flow_log                      = true
-
-  enable_ecr_api_endpoint = var.enable_ecr_api_endpoint
-  enable_ecr_dkr_endpoint = var.enable_ecr_dkr_endpoint
-  enable_dns_hostnames = var.enable_dns_hostnames
-  enable_dns_support = var.enable_dns_support
-  enable_s3_endpoint = var.enable_s3_endpoint
-  enable_logs_endpoint = var.enable_logs_endpoint
-  ecr_api_endpoint_private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
-  ecr_dkr_endpoint_private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
-
-  logs_endpoint_security_group_ids = [aws_security_group.ecr.id]
-  ecr_api_endpoint_security_group_ids  = [aws_security_group.ecr.id]
-  ecr_dkr_endpoint_security_group_ids = [aws_security_group.ecr.id]
+  create_igw = true
 
   azs = [
     "${var.region}a",
@@ -28,27 +20,12 @@ module "vpc" {
   ]
 
   private_subnets = [
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 1),
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3)
+    cidrsubnet(var.cidr_block, 8, 1),
+    cidrsubnet(var.cidr_block, 8, 2),
+    cidrsubnet(var.cidr_block, 8, 3)
   ]
-}
 
-resource "aws_security_group" "ecr" {
-  name   = "${var.prefix}-ecr"
-  vpc_id = module.vpc.vpc_id
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
-    cidr_blocks = [var.cidr_block]
-  }
-
-  egress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
-    cidr_blocks = [var.cidr_block]
-  }
+  public_subnets = [
+    cidrsubnet(var.cidr_block, 8, 4)
+  ]
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -15,11 +15,6 @@ variable "propagate_private_route_tables_vgw" {
   default = false
 }
 
-variable "cidr_block_new_bits" {
-  type    = number
-  default = 8
-}
-
 variable "ecr_api_endpoint_private_dns_enabled" {
   type = bool
   default = false


### PR DESCRIPTION
Endpoints for CloudWatch are not supported and AWS recommends using
Firelens to stream to CloudWatch. Introducing another service at this
point adds more complexity so instead adding an internet gateway to
write to CloudWatch logs. Does not affect security as these are
serverless tasks running in a private subnet.