### PR TITLE
Enable logging of the syslog ECS service

### DIFF
--- a/modules/syslog_endpoint/ecs_task_definition.tf
+++ b/modules/syslog_endpoint/ecs_task_definition.tf
@@ -10,6 +10,14 @@ resource "aws_ecs_task_definition" "server_task" {
   container_definitions = <<EOF
 [
   {
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
+        "awslogs-region": "eu-west-2",
+        "awslogs-stream-prefix": "eu-west-2-docker-logs"
+      }
+    },
     "portMappings": [
       {
         "hostPort": 514,
@@ -28,6 +36,14 @@ resource "aws_ecs_task_definition" "server_task" {
     "image": "${aws_ecr_repository.docker_repository.repository_url}",
     "expanded": true
   }, {
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
+        "awslogs-region": "eu-west-2",
+        "awslogs-stream-prefix": "eu-west-2-docker-logs"
+      }
+    },
     "portMappings": [
       {
         "hostPort": 80,


### PR DESCRIPTION
These are the CloudWatch logs generated by the running tasks processing
syslog messages.