### PR TITLE
Ship logs from dedicated Syslog CloudWatch log group

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -70,18 +70,26 @@ phases:
       - ./functionbeat -e -c ../functionbeat-config.yml package
       - zip -u package-aws.zip moj.crt moj.key elk-ca.crt
       # build templates
+      - ./functionbeat -e -c ../functionbeat-config.yml export function pttp-$ENV-infra-cloudwatch-syslog > cf-$ENV-cloudwatch-syslog.json
       - ./functionbeat -e -c ../functionbeat-config.yml export function pttp-$ENV-infra-cloudwatch > cf-$ENV-cloudwatch.json
       - ./functionbeat -e -c ../functionbeat-config.yml export function pttp-$ENV-infra-sqs        > cf-$ENV-sqs.json
       - ./functionbeat -e -c ../functionbeat-config.yml export function pttp-$ENV-infra-kinesis    > cf-$ENV-kinesis.json
 
       # upload lambdas
+      - export CW_SYSLOG_S3_KEY=`cat cf-$ENV-cloudwatch-syslog.json | jq -r '.. |."S3Key"? | select(. != null)'`
       - export CW_S3_KEY=`cat cf-$ENV-cloudwatch.json | jq -r '.. |."S3Key"? | select(. != null)'`
       - export SQS_S3_KEY=`cat cf-$ENV-sqs.json       | jq -r '.. |."S3Key"? | select(. != null)'`
       - export KINESIS_S3_KEY=`cat cf-$ENV-kinesis.json | jq -r '.. |."S3Key"? | select(. != null)'`
+      - aws s3 cp --no-progress ./package-aws.zip s3://pttp-$ENV-infra-functionbeat-artifacts/$CW_SYSLOG_S3_KEY
       - aws s3 cp --no-progress ./package-aws.zip s3://pttp-$ENV-infra-functionbeat-artifacts/$CW_S3_KEY
       - aws s3 cp --no-progress ./package-aws.zip s3://pttp-$ENV-infra-functionbeat-artifacts/$SQS_S3_KEY
       - aws s3 cp --no-progress ./package-aws.zip s3://pttp-$ENV-infra-functionbeat-artifacts/$KINESIS_S3_KEY
       # upload templates
+      - |
+        aws cloudformation deploy \
+          --stack-name pttp-$ENV-infra-cloudwatch-syslog \
+          --template-file ./cf-$ENV-cloudwatch-syslog.json \
+          --no-fail-on-empty-changeset
       - |
         aws cloudformation deploy \
           --stack-name pttp-$ENV-infra-cloudwatch \

--- a/main.tf
+++ b/main.tf
@@ -225,6 +225,10 @@ module "functionbeat_config" {
     module.customLoggingApi.log_group_name
   ]
 
+  syslog_log_groups = [
+    module.syslog_endpoint.logging.syslog_log_group_name
+  ]
+
   destination_url      = var.ost_url
   destination_username = var.ost_username
   destination_password = var.ost_password

--- a/modules/function_beats_config/variables.tf
+++ b/modules/function_beats_config/variables.tf
@@ -28,6 +28,11 @@ variable "destination_password" {
 variable "log_groups" {
   type = set(string)
 }
+
+variable "syslog_log_groups" {
+  type = set(string)
+}
+
 variable sqs_log_queue {
   type = string
 }

--- a/modules/syslog_endpoint/logging.tf
+++ b/modules/syslog_endpoint/logging.tf
@@ -4,3 +4,9 @@ resource "aws_cloudwatch_log_group" "server_log_group" {
   retention_in_days = 7
 }
 
+resource "aws_cloudwatch_log_group" "syslog_log_group" {
+  name = "${var.prefix}-syslog-log-group"
+
+  retention_in_days = 7
+}
+

--- a/modules/syslog_endpoint/outputs.tf
+++ b/modules/syslog_endpoint/outputs.tf
@@ -10,6 +10,7 @@ output "ecr" {
 output "logging" {
   value = {
     log_group_name = aws_cloudwatch_log_group.server_log_group.name
+    syslog_log_group_name = aws_cloudwatch_log_group.syslog_log_group.name
   }
 }
 


### PR DESCRIPTION
We don't want the Vector server logs combined with the actual syslogs
being sent. Create a dedicated log group for the syslog messages.

Create a new Functionbeat shipper to process this log stream and update
tags so syslogs can be identified.

Vector server needs to be updated to reference this new log group.