### PR TITLE
Rename prefix in the label module to staff-device

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ module "label" {
   source  = "cloudposse/label/null"
   version = "0.19.2"
 
-  namespace = "pttp"
+  namespace = "staff-device"
   stage     = terraform.workspace
   name      = "infra"
   delimiter = "-"


### PR DESCRIPTION
We no longer refer to this as pttp, we use staff-device instead.
Update this, which will recreate the VPC, meaning that the peering
request will need to be re-accepted.