### PR TITLE
Create a custom domain for API Gateway

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,11 +19,13 @@ env:
     TF_VAR_syslog_receiver_cidr_block:       "/staff-device/$ENV/syslog_receiver_cidr_block"
     TF_VAR_ost_vpc_id:                       "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_vpc_id"
     TF_VAR_ost_aws_account_id:               "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_aws_account_id"
+    TF_VAR_vpn_hosted_zone_id:               "/codebuild/$ENV/vpn_hosted_zone_id"
     TF_VAR_ost_vpc_cidr_block:               "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_vpc_cidr_block"
     TF_VAR_ost_username:                     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_username"
     TF_VAR_ost_password:                     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_password"
     TF_VAR_ost_url:                          "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_url"
     TF_VAR_critical_notification_recipients: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/critical_notification_recipients"
+    TF_VAR_api_gateway_custom_domain:        "/staff-device/$ENV/logging/api_gateway_domain_name"
     # function beats related config
     ROLE_ARN:                                "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
     OST_KEY:                                 "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/moj.key"

--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,9 @@ module "customLoggingApi" {
   prefix                  = module.label.id
   region                  = data.aws_region.current_region.id
   enable_api_gateway_logs = var.enable_api_gateway_logs
+  vpn_hosted_zone_id      = var.vpn_hosted_zone_id
+  api_gateway_custom_domain = var.api_gateway_custom_domain
+  tags                      = module.label.tags
 
   providers = {
     aws = aws.env

--- a/modules/custom_logging_api/apiGateway.tf
+++ b/modules/custom_logging_api/apiGateway.tf
@@ -1,3 +1,13 @@
+resource "aws_api_gateway_domain_name" "custom_logging_api" {
+  domain_name = var.api_gateway_custom_domain
+
+  regional_certificate_arn = aws_acm_certificate.api_gateway_logging.arn
+
+  endpoint_configuration {
+    types = [ "REGIONAL" ]
+  }
+}
+
 resource "aws_api_gateway_rest_api" "logging_gateway" {
   name = "${var.prefix}-CustomLogGateway"
 

--- a/modules/custom_logging_api/route53.tf
+++ b/modules/custom_logging_api/route53.tf
@@ -1,0 +1,27 @@
+resource "aws_acm_certificate" "api_gateway_logging" {
+  domain_name       = var.api_gateway_custom_domain
+  validation_method = "DNS"
+
+  tags = var.tags
+}
+
+resource "aws_acm_certificate_validation" "api_gateway_logging" {
+  certificate_arn         = aws_acm_certificate.api_gateway_logging.arn
+  validation_record_fqdns = [for record in aws_route53_record.api_gateway_logging : record.fqdn]
+}
+
+resource "aws_route53_record" "api_gateway_logging" {
+  for_each = {
+    for dvo in aws_acm_certificate.api_gateway_logging.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  ttl     = 3600
+  type    = each.value.type
+  zone_id = var.vpn_hosted_zone_id
+}

--- a/modules/custom_logging_api/variables.tf
+++ b/modules/custom_logging_api/variables.tf
@@ -15,3 +15,15 @@ variable "stage_name" {
   type    = string
   default = "main"
 }
+
+variable "vpn_hosted_zone_id" {
+  type = string
+}
+
+variable "api_gateway_custom_domain" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,11 @@ variable "transit_gateway_id" {
 variable "transit_gateway_route_table_id" {
   type = string
 }
+
+variable "vpn_hosted_zone_id" {
+  type = string
+}
+
+variable "api_gateway_custom_domain" {
+  type = string
+}


### PR DESCRIPTION
We need a predictable domain for API gateway for receiving logs.
This creates a record and certificate which is then added to the API
gateway.